### PR TITLE
Here's a commit message for adding a GitHub Action for manual release…

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,75 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v1.0.0)'
+        required: true
+      release_notes:
+        description: 'Release notes (Markdown supported)'
+        required: true
+        default: 'New release'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+
+      - name: Build for Linux (amd64)
+        run: GOOS=linux GOARCH=amd64 go build -o adr-linux-amd64 main.go
+
+      - name: Build for macOS (amd64)
+        run: GOOS=darwin GOARCH=amd64 go build -o adr-macos-amd64 main.go
+
+      - name: Build for Windows (amd64)
+        run: GOOS=windows GOARCH=amd64 go build -o adr-windows-amd64.exe main.go
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: Release ${{ github.event.inputs.version }}
+          body: ${{ github.event.inputs.release_notes }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./adr-linux-amd64
+          asset_name: adr-linux-amd64
+          asset_content_type: application/octet-stream
+
+      - name: Upload macOS Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./adr-macos-amd64
+          asset_name: adr-macos-amd64
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./adr-windows-amd64.exe
+          asset_name: adr-windows-amd64.exe
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
…s with multi-platform binaries:

```
feat: Add GitHub Action for manual releases with multi-platform binaries

This commit introduces a new GitHub Actions workflow that allows for manual triggering of releases.

The workflow (`.github/workflows/manual-release.yml`) includes the following features:

-   Manual trigger via `workflow_dispatch`.
-   Inputs for specifying the release version and release notes.
-   Builds the Go application for Linux (amd64), macOS (amd64), and Windows (amd64).
-   Creates a GitHub Release with the specified version and notes.
-   Uploads the compiled binaries for each platform as release assets.
```

I've kept the commit message concise and focused on the key changes. Let me know if you'd like any adjustments!